### PR TITLE
Add a layman repositories.xml file

### DIFF
--- a/layman.xml
+++ b/layman.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE repositories SYSTEM "/dtd/repositories.dtd">
+<repositories xmlns="" version="1.0">
+  <repo quality="testing" status="unofficial">
+    <name><![CDATA[obs-studio-overlay]]></name>
+    <description lang="en"><![CDATA[Gentoo overlay for OBS Studio]]></description>
+    <homepage>https://github.com/saintdev/obs-studio-overlay</homepage>
+    <owner type="person">
+      <name><![CDATA[saintdev]]></name>
+      <!--<email></email>-->
+    </owner>
+    <source type="git">git://github.com/saintdev/obs-studio-overlay.git</source>
+    <source type="git">https://github.com/saintdev/obs-studio-overlay.git</source>
+    <feed>https://github.com/saintdev/obs-studio-overlay/commits/master.atom</feed>
+  </repo>
+</repositories>


### PR DESCRIPTION
So the overlay can be added easily to layman by adding
  https://raw.github.com/saintdev/obs-studio-overlay/master/layman.xml
to the overlays variable in layman.cfg
