### PR TITLE
Make OBS use lib32 / lib64 instead of lib

### DIFF
--- a/media-video/obs-studio/obs-studio-9999.ebuild
+++ b/media-video/obs-studio/obs-studio-9999.ebuild
@@ -68,6 +68,7 @@ src_configure() {
 		$(cmake-utils_use_disable truetype FREETYPE)
 		$(cmake-utils_use_disable v4l V4L2)
 		-DUNIX_STRUCTURE=1
+		-DOBS_MULTIARCH_SUFFIX=$(sed 's/lib//' <<< $(get_libdir))
 	)
 
 	cmake-utils_src_configure


### PR DESCRIPTION
This commit fixes #12.

I am not sure of the style on how to apply this properly, but `sed <<< get_lib` seems one way.
